### PR TITLE
Fixed crash when no "Content-Type" header is set

### DIFF
--- a/lib/urna/backend.ex
+++ b/lib/urna/backend.ex
@@ -5,7 +5,7 @@ defmodule Urna.Backend do
   def decode(req, adapters) do
     [type|_] = req
       |> Request.headers
-      |> Dict.get("Content-Type")
+      |> Dict.get("Content-Type", "")
       |> String.split("; ")
     adapter   = Enum.find adapters, &(&1.accept?(type))
     body      = req |> Request.body


### PR DESCRIPTION
When doing a a simple "GET" without the "Content-Type" header the program exceptions this way:
15:45:47.079 [error] Error in process <0.400.0> with exit value: {badarg,[{binary,split,3,[{file,"binary.erl"},{line,242}]},{'Elixir.Urna.Backend',decode,2,[{file,"lib/urna/backend.ex"},{line,9}]},{'Elixir.RESTTest',handle,3,[{file,"lib/rest_test.ex"},{line,4}]}]}
The solution? 
Give Dict.get/2 the Dict.get/3 treatment and set a default: "", otherwise you are pipeing a *nil* to the String.split/2 method

Now you can test your API from any browser/REST client without having to set the header Content-Type all the time when not needed :)